### PR TITLE
Fix survey refresh overlay when reloading survey

### DIFF
--- a/site-survey_fixed_v7.html
+++ b/site-survey_fixed_v7.html
@@ -1810,6 +1810,8 @@
         }
 
     function initializeMainApp(r2Number, eventName = '', venueName = '') {
+            // Enter survey mode so dashboard doesn't overlay after refresh
+            window.inSurveyMode = true;
             // Set global app ID
             window.appId = r2Number;
             


### PR DESCRIPTION
## Summary
- Ensure survey mode flag is set when initializing a survey so the dashboard is hidden after refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3a3471e4832eb772355e8a6d3212