### PR TITLE
Add domain-based development mode bypass

### DIFF
--- a/CONFIG_REFERENCE.js
+++ b/CONFIG_REFERENCE.js
@@ -50,9 +50,9 @@ const msalConfig = {
  * - user: Default role for new users
  */
 
-/* 
+/*
  * DEVELOPMENT MODE:
- * - Automatically activates on localhost/127.0.0.1
- * - Uses mock admin user for testing
+ * - Automatically activates when site is not running on ita.com
+ * - Uses mock admin user Alex.Greene@ita.com for testing
  * - All features work without Azure configuration
  */

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -4,7 +4,7 @@
 
 ### 🔐 Authentication System
 - **Microsoft SSO Integration**: Uses MSAL.js for Azure AD authentication
-- **Development Mode**: Automatic bypass for localhost/127.0.0.1 (Live Server compatible)
+- **Development Mode**: Automatic bypass when site is not running on ita.com (Live Server compatible)
 - **Production Mode**: Full Microsoft authentication required
 - **Session Management**: Real-time user tracking with Supabase
 
@@ -30,16 +30,16 @@
 - **Domain Restrictions**: Azure validates all requests against registered redirect URIs
 
 ### 🛠️ Development Features
-- **Live Server Compatible**: Automatic development mode detection
+- **Domain-Based Detection**: Automatically enters development mode on non-ita.com domains
 - **Mock Authentication**: Uses admin account for local testing
 - **All Features Available**: Complete functionality in development
 - **Easy Deployment**: Works with WordPress or standalone hosting
 
 ## 🚀 How to Use
 
-### For Development (Live Server)
-1. Open site-survey.html in VS Code
-2. Use Live Server extension (Go Live)
+### For Development (Local or Staging)
+1. Open `site-survey.html` in VS Code
+2. Use Live Server extension (Go Live) or host on any non-ita.com domain
 3. Application automatically:
    - Bypasses Microsoft SSO
    - Logs you in as admin user

--- a/site-survey_fixed_v7.html
+++ b/site-survey_fixed_v7.html
@@ -8615,34 +8615,35 @@ Focus on practical information that would affect event planning, setup, logistic
         // Initialize authentication
         async function initAuth() {
             try {
-                // For Live Server development - check if we're in localhost
-                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+                // Development mode - active when not running on ita.com
+                const hostname = window.location.hostname.toLowerCase();
+                if (!hostname.endsWith('ita.com')) {
                     console.log('Development mode - bypassing Microsoft SSO');
-                    // Create mock user for development
+                    // Create mock admin user for development
                     currentUser = {
                         account: {
-                            username: 'alex.greene@ita.com',
+                            username: 'Alex.Greene@ita.com',
                             name: 'Alex Greene (Dev)',
                             idTokenClaims: {
-                                email: 'alex.greene@ita.com'
+                                email: 'Alex.Greene@ita.com'
                             }
                         }
                     };
-                    
+
                     // Immediately show main app and hide auth container for development
                     showMainApp();
-                    
+
                     // Set up the authenticated user
-                    window.currentUserEmail = 'alex.greene@ita.com';
+                    window.currentUserEmail = 'Alex.Greene@ita.com';
                     window.currentUserName = 'Alex Greene (Dev)';
                     window.currentUserRole = 'admin';
-                    
+
                     // Update UI
-                    updateUserInterface('Alex Greene (Dev)', 'alex.greene@ita.com', 'admin');
-                    
+                    updateUserInterface('Alex Greene (Dev)', 'Alex.Greene@ita.com', 'admin');
+
                     // Track user session in development mode
-                    await trackUserSession('alex.greene@ita.com', 'Alex Greene (Dev)', 'admin');
-                    
+                    await trackUserSession('Alex.Greene@ita.com', 'Alex Greene (Dev)', 'admin');
+
                     // Initialize the survey app
                     initializeSurveyApp();
                     return;


### PR DESCRIPTION
## Summary
- Bypass Microsoft SSO automatically when the site isn't served from an `ita.com` domain and log in as mock admin `Alex.Greene@ita.com`
- Document domain-based dev mode and mock admin user
- Clarify development mode activation in implementation summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b51eda8e4832ebf8f6d59bdecb1ae