### PR TITLE
Disable Microsoft SSO and default to admin user

### DIFF
--- a/CONFIG_REFERENCE.js
+++ b/CONFIG_REFERENCE.js
@@ -50,9 +50,9 @@ const msalConfig = {
  * - user: Default role for new users
  */
 
-/* 
- * DEVELOPMENT MODE:
- * - Automatically activates on localhost/127.0.0.1
- * - Uses mock admin user for testing
- * - All features work without Azure configuration
+/*
+ * AUTHENTICATION STATUS:
+ * - Microsoft SSO temporarily disabled
+ * - All users are logged in as admin Alex.Greene@ita.com
+ * - Re-enable SSO by setting MS_AUTH_ENABLED to true in the HTML
  */

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3,9 +3,8 @@
 ## ✅ What's Been Implemented
 
 ### 🔐 Authentication System
-- **Microsoft SSO Integration**: Uses MSAL.js for Azure AD authentication
-- **Development Mode**: Automatic bypass for localhost/127.0.0.1 (Live Server compatible)
-- **Production Mode**: Full Microsoft authentication required
+- **Microsoft SSO Integration**: Implemented with MSAL.js but currently disabled
+- **Current Mode**: All visitors are automatically logged in as admin (Alex.Greene@ita.com)
 - **Session Management**: Real-time user tracking with Supabase
 
 ### 🗄️ Database Migration to Supabase
@@ -22,7 +21,7 @@
 - **User**: Create/edit venues and events, no venue list access
 
 ### 🎯 Security Features
-- **Authentication**: Microsoft SSO required in production
+- **Authentication**: Microsoft SSO integration available but currently disabled
 - **Authorization**: Role-based permissions for all operations
 - **Session Tracking**: Active user monitoring and management
 - **Access Controls**: Database restrictions by role
@@ -30,18 +29,16 @@
 - **Domain Restrictions**: Azure validates all requests against registered redirect URIs
 
 ### 🛠️ Development Features
-- **Live Server Compatible**: Automatic development mode detection
-- **Mock Authentication**: Uses admin account for local testing
-- **All Features Available**: Complete functionality in development
+- **SSO Disabled**: Microsoft authentication is temporarily bypassed
+- **Mock Authentication**: All environments use the admin account
+- **All Features Available**: Complete functionality without Azure setup
 - **Easy Deployment**: Works with WordPress or standalone hosting
 
 ## 🚀 How to Use
 
-### For Development (Live Server)
-1. Open site-survey.html in VS Code
-2. Use Live Server extension (Go Live)
-3. Application automatically:
-   - Bypasses Microsoft SSO
+### For Development (Local or Staging)
+1. Open `site-survey.html` in any browser or use a simple web server
+2. Application automatically:
    - Logs you in as admin user
    - Shows full functionality
    - No configuration needed
@@ -373,8 +370,7 @@ const supabaseConfig = {
 - Backward compatible
 
 ## 🧪 Testing
-- **Development**: Full functionality with mock admin user
-- **Production**: Real Microsoft authentication required
+- **Current Build**: Full functionality with mock admin user
 - **Role Testing**: Use admin panel to test different roles
 - **Mobile Testing**: Test camera and touch features
 
@@ -405,7 +401,7 @@ const supabaseConfig = {
    });
    ```
 
-3. **Microsoft Authentication Issues**
+3. **Microsoft Authentication Issues** (when SSO is re-enabled)
    - Verify redirect URI exactly matches your URL
    - Check Azure AD app permissions are granted
    - Test with `?dev=true` parameter first
@@ -418,15 +414,15 @@ const supabaseConfig = {
 **🔍 Testing Checklist:**
 - [ ] File accessible at correct URL
 - [ ] HTTPS enabled on WordPress site
-- [ ] Azure AD app configured correctly
-- [ ] Test user can sign in with Microsoft
+- [ ] Azure AD app configured correctly (for future SSO)
+- [ ] Test user can sign in with Microsoft (once SSO is re-enabled)
 - [ ] Photos upload successfully
 - [ ] Mobile interface works
 - [ ] AI features function (if configured)
 
-**🚨 Emergency Development Mode:**
+**🚨 Emergency Development Mode:** (currently unnecessary since SSO is disabled)
 - Add `?dev=true` to any URL for testing
-- Bypasses authentication
+- Bypasses authentication (not required in current build)
 - Gives full admin access
 - Example: `https://yoursite.com/site-survey.html?id=TEST&dev=true`
 

--- a/MICROSOFT_SSO_SETUP.md
+++ b/MICROSOFT_SSO_SETUP.md
@@ -1,6 +1,8 @@
 # Microsoft SSO Setup Guide for Site Survey Application
 
 ## Overview
+> **Note:** Microsoft SSO is currently disabled in the application. The instructions below apply when SSO is re-enabled.
+
 This guide will help you configure Microsoft Single Sign-On (SSO) authentication for your site survey application with role-based access control.
 
 ## Security Levels Implemented

--- a/site-survey_fixed_v7.html
+++ b/site-survey_fixed_v7.html
@@ -8606,6 +8606,9 @@ Focus on practical information that would affect event planning, setup, logistic
         let msalInstance;
         let currentUser = null;
 
+        // Toggle for Microsoft authentication
+        const MS_AUTH_ENABLED = false; // Set to true to re-enable Microsoft SSO
+
         // User roles mapping
         const userRoles = {
             'alex.greene@ita.com': 'admin'
@@ -8615,34 +8618,34 @@ Focus on practical information that would affect event planning, setup, logistic
         // Initialize authentication
         async function initAuth() {
             try {
-                // For Live Server development - check if we're in localhost
-                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-                    console.log('Development mode - bypassing Microsoft SSO');
-                    // Create mock user for development
+                // Development-only authentication (Microsoft SSO disabled)
+                if (!MS_AUTH_ENABLED) {
+                    console.log('Microsoft SSO disabled - bypassing authentication');
+                    // Create mock admin user for all access
                     currentUser = {
                         account: {
-                            username: 'alex.greene@ita.com',
-                            name: 'Alex Greene (Dev)',
+                            username: 'Alex.Greene@ita.com',
+                            name: 'Alex Greene (Admin)',
                             idTokenClaims: {
-                                email: 'alex.greene@ita.com'
+                                email: 'Alex.Greene@ita.com'
                             }
                         }
                     };
-                    
-                    // Immediately show main app and hide auth container for development
+
+                    // Immediately show main app and hide auth container
                     showMainApp();
-                    
+
                     // Set up the authenticated user
-                    window.currentUserEmail = 'alex.greene@ita.com';
-                    window.currentUserName = 'Alex Greene (Dev)';
+                    window.currentUserEmail = 'Alex.Greene@ita.com';
+                    window.currentUserName = 'Alex Greene (Admin)';
                     window.currentUserRole = 'admin';
-                    
+
                     // Update UI
-                    updateUserInterface('Alex Greene (Dev)', 'alex.greene@ita.com', 'admin');
-                    
-                    // Track user session in development mode
-                    await trackUserSession('alex.greene@ita.com', 'Alex Greene (Dev)', 'admin');
-                    
+                    updateUserInterface('Alex Greene (Admin)', 'Alex.Greene@ita.com', 'admin');
+
+                    // Track user session in this temporary mode
+                    await trackUserSession('Alex.Greene@ita.com', 'Alex Greene (Admin)', 'admin');
+
                     // Initialize the survey app
                     initializeSurveyApp();
                     return;
@@ -8683,6 +8686,10 @@ Focus on practical information that would affect event planning, setup, logistic
 
         // Handle Microsoft login
         async function handleMicrosoftLogin() {
+            if (!MS_AUTH_ENABLED) {
+                console.log('Microsoft SSO is disabled');
+                return;
+            }
             if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
                 // Development bypass
                 return;


### PR DESCRIPTION
## Summary
- Bypass Microsoft SSO entirely and automatically sign all users in as admin `Alex.Greene@ita.com`
- Document that SSO is disabled and can be re-enabled with `MS_AUTH_ENABLED`
- Add a note to the SSO setup guide explaining the temporary shutdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b51eda8e4832ebf8f6d59bdecb1ae